### PR TITLE
Improve vscode-eslint build script in order to lock version, but with git tags instead of commit hash

### DIFF
--- a/script/build-vscode-eslint.sh
+++ b/script/build-vscode-eslint.sh
@@ -2,19 +2,22 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+# Latest stable release for vscode-eslint is 2.4.4
+# https://github.com/microsoft/vscode-eslint/tags
+RELEASE_TAG="release/2.4.4"
+
 # prepare
 mkdir -p $DIR/../tmp
 mkdir -p $DIR/../dist
 
 # clone
 cd $DIR/../tmp
-git clone --depth=1 git@github.com:Microsoft/vscode-eslint vscode-eslint
+git clone git@github.com:Microsoft/vscode-eslint vscode-eslint
 
 # pull
 cd $DIR/../tmp/vscode-eslint
 git clean -fd
-git checkout .
-git pull --rebase
+git checkout tags/$RELEASE_TAG
 
 # npm install
 cd $DIR/../tmp/vscode-eslint


### PR DESCRIPTION
Related:
https://github.com/hrsh7th/vscode-langservers-extracted/pull/10
https://github.com/hrsh7th/vscode-langservers-extracted/commit/859ca87fd778a862ee2c9f4c03017775208d033a#comments
https://github.com/neovim/nvim-lspconfig/issues/3146